### PR TITLE
Do not add sizes to apple-touch-icon when not defined

### DIFF
--- a/lib/apple-link-tags.js
+++ b/lib/apple-link-tags.js
@@ -7,11 +7,18 @@ var hasTarget = require('./has-target');
 
 function appleLinkTags(manifest, config) {
   var links = [];
+  var sizes;
 
   if (manifest.icons && manifest.icons.length) {
     for(var icon of manifest.icons) {
       if (!icon.targets || hasTarget(icon, 'apple')) {
-        links.push(`<link rel="apple-touch-icon" href="${config.rootURL}${icon.src.replace(/^\//,'')}" sizes="${icon.sizes}">`);
+        if (icon.sizes) {
+          sizes = ` sizes="${icon.sizes}"`
+        } else {
+          sizes = '';
+        }
+
+        links.push(`<link rel="apple-touch-icon" href="${config.rootURL}${icon.src.replace(/^\//,'')}"${sizes}>`);
       }
     }
   }

--- a/node-tests/unit/apple-link-tags-test.js
+++ b/node-tests/unit/apple-link-tags-test.js
@@ -72,4 +72,23 @@ describe('Unit: appleLinkTags()', function() {
 
     assert.deepEqual(appleLinkTags(manifest, config), expected);
   });
+
+  it('does not render sizes attribute when is not defined', function() {
+    var config = {
+      rootURL: '/'
+    };
+    var manifest = {
+      icons: [
+        {
+          src: '/foo/bar.png'
+        }
+      ]
+    };
+
+    var expected = [
+      '<link rel="apple-touch-icon" href="/foo/bar.png">',
+    ];
+
+    assert.deepEqual(appleLinkTags(manifest, config), expected);
+  });
 });


### PR DESCRIPTION
Fixes #16 