### PR TITLE
Avoid watching tmp/ and dist/ folders on Ubuntu

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
 
     var GenerateManifest = require('./lib/broccoli/generate-manifest-json');
 
-    return new GenerateManifest('.', generateManifestFromConfiguration(this.manifestConfiguration));
+    return new GenerateManifest(generateManifestFromConfiguration(this.manifestConfiguration));
   },
 
   contentFor: function(section, config) {

--- a/lib/broccoli/generate-manifest-json.js
+++ b/lib/broccoli/generate-manifest-json.js
@@ -7,8 +7,11 @@ module.exports = GenerateManifest;
 
 GenerateManifest.prototype = Object.create(Plugin.prototype);
 GenerateManifest.prototype.constructor = GenerateManifest;
-function GenerateManifest(inputNode, manifest) {
-  Plugin.call(this, [inputNode]);
+function GenerateManifest(manifest) {
+  // We don't need any input node
+  Plugin.call(this, [], {
+    annotation: 'generate manifest.json'
+  });
 
   this.manifest = manifest;
 }

--- a/node-tests/broccoli/generate-manifest-json-test.js
+++ b/node-tests/broccoli/generate-manifest-json-test.js
@@ -11,8 +11,8 @@ describe('Broccoli: ProcessManifest', function() {
   var GenerateManifestHelper = makeTestHelper({
     fixturePath: __dirname,
 
-    subject: function(inputNode) {
-      return new GenerateManifest(inputNode, { foo: 'bar', apple: 'baz', ms: 'qux' });
+    subject: function() {
+      return new GenerateManifest({ foo: 'bar', apple: 'baz', ms: 'qux' });
     },
   });
 
@@ -21,7 +21,7 @@ describe('Broccoli: ProcessManifest', function() {
   });
 
   it('generates manifest.json file', function() {
-    return GenerateManifestHelper('fixtures')
+    return GenerateManifestHelper()
       .then(function(result) {
         assert.deepEqual(result.files, ['manifest.json']);
         return path.join(result.directory, result.files[0]);


### PR DESCRIPTION
Under some conditions we were watching the tmp/ and dist/ folders making `ember serve` to go crazy and never stop building the application.

By specifying the source nodes as an empty array we avoid this.