### PR TITLE
Rename  manifest.json to manifest.ember-web-app.json during build

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /* jshint node: true */
 'use strict';
 
+var fs = require('fs');
+
 module.exports = {
   name: 'ember-web-app',
 
@@ -59,5 +61,9 @@ module.exports = {
     } catch(e) {
       return {};
     }
+  },
+
+  postBuild(results) {
+    fs.renameSync(results.directory + '/' + require('./lib/constants').TEMP_MANIFEST, results.directory + '/manifest.json');
   }
 };

--- a/lib/broccoli/generate-manifest-json.js
+++ b/lib/broccoli/generate-manifest-json.js
@@ -21,6 +21,6 @@ GenerateManifest.prototype.build = function() {
   var join = require('path').join;
 
   writeFileSync(
-    join(this.outputPath, 'manifest.json'),
+    join(this.outputPath, require('../constants').TEMP_MANIFEST),
     JSON.stringify(this.manifest) + '\n');
 };

--- a/lib/configure-fingerprint.js
+++ b/lib/configure-fingerprint.js
@@ -10,33 +10,21 @@ function configureFingerprint(currentOptions) {
   }
 
   var defaultOptions = require('broccoli-asset-rev/lib/default-options');
-  var fingerprint;
+  var fingerprint = {};
 
-  if (currentOptions == null) {
-    fingerprint = {
-      exclude: defaultOptions.exclude.concat(['manifest.json']),
-      replaceExtensions: defaultOptions.replaceExtensions.concat(['json'])
-    };
-  } else {
-    // fingerprint is configured, update the configuration
-    fingerprint = {};
-
+  if (currentOptions != null) {
     for(var option in currentOptions) {
       fingerprint[option] = currentOptions[option];
     }
-
-    if (fingerprint.exclude) {
-      fingerprint.exclude = fingerprint.exclude.concat(['manifest.json']);
-    } else {
-      fingerprint.exclude = defaultOptions.exclude.concat(['manifest.json']);
-    }
-
-    if (fingerprint.replaceExtensions) {
-      fingerprint.replaceExtensions = fingerprint.replaceExtensions.concat(['json']);
-    } else {
-      fingerprint.replaceExtensions = defaultOptions.replaceExtensions.concat(['json']);
-    }
   }
+
+  var manifest = require('./constants').TEMP_MANIFEST;
+
+  var exclude = fingerprint.exclude || defaultOptions.exclude;
+  fingerprint.exclude = exclude.concat([manifest]);
+
+  var replaceExtensions = fingerprint.replaceExtensions || defaultOptions.replaceExtensions;
+  fingerprint.replaceExtensions = replaceExtensions.concat([manifest.match(/\.(.*$)/)[1]]);
 
   return fingerprint;
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // Use a unique extension so we don't affect other files when fingerprinting.
+  TEMP_MANIFEST: 'manifest.ember-web-app.json'
+};

--- a/node-tests/broccoli/generate-manifest-json-test.js
+++ b/node-tests/broccoli/generate-manifest-json-test.js
@@ -23,7 +23,7 @@ describe('Broccoli: ProcessManifest', function() {
   it('generates manifest.json file', function() {
     return GenerateManifestHelper()
       .then(function(result) {
-        assert.deepEqual(result.files, ['manifest.json']);
+        assert.deepEqual(result.files, ['manifest.ember-web-app.json']);
         return path.join(result.directory, result.files[0]);
       })
       .then(readManifest)

--- a/node-tests/unit/configure-fingerprint-test.js
+++ b/node-tests/unit/configure-fingerprint-test.js
@@ -11,8 +11,8 @@ describe('Unit: configureFingerprint()', function() {
 
   it('returns safe configuration when options is undefined', function() {
     var expected = {
-      exclude: ['manifest.json'],
-      replaceExtensions: ['html', 'css', 'js', 'json']
+      exclude: ['manifest.ember-web-app.json'],
+      replaceExtensions: ['html', 'css', 'js', 'ember-web-app.json']
     };
 
     var actual = configureFingerprint(undefined);
@@ -28,8 +28,8 @@ describe('Unit: configureFingerprint()', function() {
     };
     var expected = {
       prepend: 'prefix',
-      exclude: ['foo', 'bar', 'manifest.json'],
-      replaceExtensions: ['baz', 'json']
+      exclude: ['foo', 'bar', 'manifest.ember-web-app.json'],
+      replaceExtensions: ['baz', 'ember-web-app.json']
     };
 
     var actual = configureFingerprint(userOptions);
@@ -43,8 +43,8 @@ describe('Unit: configureFingerprint()', function() {
     };
     var expected = {
       prepend: 'prefix',
-      exclude: ['manifest.json'],
-      replaceExtensions: ['html', 'css', 'js', 'json']
+      exclude: ['manifest.ember-web-app.json'],
+      replaceExtensions: ['html', 'css', 'js', 'ember-web-app.json']
     };
 
     var actual = configureFingerprint(userOptions);


### PR DESCRIPTION
In order to avoid adding `json` to `replaceExtension` in broccoli-asset-rev, we now add `ember-web-app.json`.

Fixes https://github.com/san650/ember-web-app/issues/5