### PR TITLE
Rename manifest.json to manifest.ember-web-app.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ From [MDN](https://developer.mozilla.org/en-US/docs/Web/Manifest)
 
 Addon features:
 
-* Generates a manifest.json file using a JavaScript template
+* Generates a manifest.ember-web-app.json file using a JavaScript template
 * Uses fingerprint for images
 * Generates equivalent meta tags for supporting other devices (e.g. iPhone)
 * Validates the configuration
@@ -71,7 +71,7 @@ It will generate the following meta tags
 `index.html`
 
 ```html
-<link rel="manifest" href="/manifest.json">
+<link rel="manifest" href="/manifest.ember-web-app.json">
 <link rel="apple-touch-icon" href="/images/icons/android-chrome-192x192-883114367f2d72fc9a509409454a1e73.png" sizes="192x192">
 <link rel="apple-touch-icon" href="/images/icons/android-chrome-512x512-af3d768ff652dc2be589a3c22c6dc827.png" sizes="512x512">
 <link rel="apple-touch-icon" href="/images/icons/apple-touch-icon-36cba25bc155e8ba414265f9d85861ca.png" sizes="180x180">
@@ -81,7 +81,7 @@ It will generate the following meta tags
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 ```
 
-and the following `manifest.json` file
+and the following `manifest.ember-web-app.json` file
 
 ```json
 {

--- a/index.js
+++ b/index.js
@@ -61,9 +61,5 @@ module.exports = {
     } catch(e) {
       return {};
     }
-  },
-
-  postBuild(results) {
-    fs.renameSync(results.directory + '/' + require('./lib/constants').TEMP_MANIFEST, results.directory + '/manifest.json');
   }
 };

--- a/lib/android-link-tags.js
+++ b/lib/android-link-tags.js
@@ -4,7 +4,9 @@
 module.exports = androidLinkTags;
 
 function androidLinkTags(manifest, config) {
+  var name = require('./constants').TEMP_MANIFEST;
+
   return [
-    `<link rel="manifest" href="${config.rootURL}manifest.json">`
+    `<link rel="manifest" href="${config.rootURL}${name}">`
   ];
 }

--- a/node-tests/acceptance/manifest-test.js
+++ b/node-tests/acceptance/manifest-test.js
@@ -17,7 +17,7 @@ describe('Acceptance: manifest file generation', function() {
     app = new AddonTestApp();
   });
 
-  it('generates a manifest.json file', function() {
+  it('generates a manifest.ember-web-app.json file', function() {
     return app.create('empty', {
         fixturesPath: 'node-tests/acceptance/fixtures'
       })
@@ -25,7 +25,7 @@ describe('Acceptance: manifest file generation', function() {
         return app.runEmberCommand('build');
       })
       .then(function() {
-        return readFile(app.filePath('/dist/manifest.json'), { encoding: 'utf-8' });
+        return readFile(app.filePath('/dist/manifest.ember-web-app.json'), { encoding: 'utf-8' });
       })
       .then(function(content) {
         assert.deepEqual(JSON.parse(content), {
@@ -50,7 +50,7 @@ describe('Acceptance: manifest file generation', function() {
         return app.runEmberCommand('build', '--prod');
       })
       .then(function() {
-        return readFile(app.filePath('/dist/manifest.json'), { encoding: 'utf-8' });
+        return readFile(app.filePath('/dist/manifest.ember-web-app.json'), { encoding: 'utf-8' });
       })
       .then(function(content) {
         // fingerprint images

--- a/node-tests/unit/android-link-tags-test.js
+++ b/node-tests/unit/android-link-tags-test.js
@@ -11,7 +11,7 @@ describe('Unit: androidLinkTags()', function() {
       rootURL: '/foo/bar/'
     };
     var expected = [
-      '<link rel="manifest" href="/foo/bar/manifest.json">'
+      '<link rel="manifest" href="/foo/bar/manifest.ember-web-app.json">'
     ];
 
     assert.deepEqual(androidLinkTags(manifest, config), expected);

--- a/node-tests/unit/index-test.js
+++ b/node-tests/unit/index-test.js
@@ -13,7 +13,7 @@ function createIndex() {
 describe('Unit: index', function() {
   describe('contentFor()', function() {
     it('returns link tag when section is "head"', function() {
-      var expected = '<link rel="manifest" href="/manifest.json">';
+      var expected = '<link rel="manifest" href="/manifest.ember-web-app.json">';
       var index = createIndex();
       index.manifestConfiguration = {};
 
@@ -27,7 +27,7 @@ describe('Unit: index', function() {
     });
 
     it('uses rootURL config', function() {
-      var expected = '<link rel="manifest" href="/foo/bar/manifest.json">';
+      var expected = '<link rel="manifest" href="/foo/bar/manifest.ember-web-app.json">';
       var index = createIndex();
       index.manifestConfiguration = {};
 


### PR DESCRIPTION
This avoids the need to rename the file in the `afterBuild` hook which causes problems in rebuilds.