### PR TITLE
Support iOS precomposed suffix for icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See the [documentation](#documentation) section below for more information.
   * [`start_url`](#start_url)
   * [`theme_color`](#theme_color)
   * [`apple.statusBarStyle`](#applestatusbarstyle)
+  * [`apple.precomposed`](#appleprecomposed)
 * [Development](#development)
 * [Project's health](#projects-health)
 * [License](#license)
@@ -511,6 +512,31 @@ manifest.apple = {
 | ---        | ---       |
 | `manifest` | does not apply
 | `apple`    | `<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">`
+| `ms`       | does not apply
+| `android`  | does not apply
+
+#### `apple.precomposed`
+
+> Adds `precomposed` suffix to apple touch icons
+
+See [Precomposed Keyword for apple touch icons](https://mathiasbynens.be/notes/touch-icons#effects)
+
+Possible values:
+  * `true` Adds precomposed suffix.
+  * `false` (default) Does not add precomposed suffix.
+
+Example
+
+```js
+manifest.apple = {
+ precomposed: 'true'
+};
+```
+
+| Target     | Generates |
+| ---        | ---       |
+| `manifest` | does not apply
+| `apple`    | `<link rel="apple-touch-icon-precomposed" href="/images/icons/apple-touch-icon-192x192.png" sizes="192x192">`
 | `ms`       | does not apply
 | `android`  | does not apply
 

--- a/lib/apple-link-tags.js
+++ b/lib/apple-link-tags.js
@@ -9,6 +9,14 @@ function appleLinkTags(manifest, config) {
   var sizes;
   var rootURL = config.rootURL || '/';
 
+  var precomposed;
+
+  if(manifest.apple && manifest.apple.precomposed) {
+    precomposed = '-precomposed';
+  } else {
+    precomposed = '';
+  }
+
   if (manifest.icons && manifest.icons.length) {
     for(var icon of manifest.icons) {
       if (!icon.targets || hasTarget(icon, 'apple')) {
@@ -18,7 +26,7 @@ function appleLinkTags(manifest, config) {
           sizes = '';
         }
 
-        links.push(`<link rel="apple-touch-icon" href="${rootURL}${icon.src.replace(/^\//,'')}"${sizes}>`);
+        links.push(`<link rel="apple-touch-icon${precomposed}" href="${rootURL}${icon.src.replace(/^\//,'')}"${sizes}>`);
       }
     }
   }

--- a/node-tests/unit/apple-link-tags-test.js
+++ b/node-tests/unit/apple-link-tags-test.js
@@ -108,4 +108,27 @@ describe('Unit: appleLinkTags()', function() {
 
     assert.deepEqual(appleLinkTags(manifest, config), expected);
   });
+
+  it('generates icons with precomposed suffix', function() {
+    var config = {
+      rootURL: '/'
+    };
+
+    var manifest = {
+      icons: [
+        {
+          src: '/foo/bar.png'
+        }
+      ],
+      apple: {
+        precomposed: true
+      }
+    };
+
+    var expected = [
+      '<link rel="apple-touch-icon-precomposed" href="/foo/bar.png">',
+    ];
+
+    assert.deepEqual(appleLinkTags(manifest, config), expected);
+  });
 });


### PR DESCRIPTION
Support to add the precomposed keyword in icons links like `<link rel="apple-touch-icon-precomposed" href="/images/icons/apple-touch-icon-192x192.png" sizes="192x192">`