### PR TITLE
Remove hack on acceptance tests

### DIFF
--- a/node-tests/acceptance/manifest-test.js
+++ b/node-tests/acceptance/manifest-test.js
@@ -45,16 +45,6 @@ describe('Acceptance: manifest file generation', function() {
         fixturesPath: 'node-tests/acceptance/fixtures'
       })
       .then(function() {
-        // WORKAROUND: ember-cli-addon-tests doesn't include in the
-        // package.json packages installed with blueprint's addPackageToProject
-        // are not copied when re-generating the app with a new name
-        //
-        // See https://github.com/tomdale/ember-cli-addon-tests/issues/27
-        app.editPackageJSON(function(pkg) {
-          pkg['devDependencies']['ember-web-app-rename'] = '*';
-        });
-      })
-      .then(function() {
         return app.runEmberCommand('build', '--prod')
       })
       .then(contentOf(app, 'dist/manifest.json'))
@@ -69,16 +59,6 @@ describe('Acceptance: manifest file generation', function() {
     return app
       .create('config-name', {
         fixturesPath: 'node-tests/acceptance/fixtures'
-      })
-      .then(function() {
-        // WORKAROUND: ember-cli-addon-tests doesn't include in the
-        // package.json packages installed with blueprint's addPackageToProject
-        // are not copied when re-generating the app with a new name
-        //
-        // See https://github.com/tomdale/ember-cli-addon-tests/issues/27
-        app.editPackageJSON(function(pkg) {
-          pkg['devDependencies']['ember-web-app-rename'] = '*';
-        });
       })
       .then(function() {
         return app.runEmberCommand('build')
@@ -97,16 +77,6 @@ describe('Acceptance: manifest file generation', function() {
     return app
       .create('disabled', {
         fixturesPath: 'node-tests/acceptance/fixtures'
-      })
-      .then(function() {
-        // WORKAROUND: ember-cli-addon-tests doesn't include in the
-        // package.json packages installed with blueprint's addPackageToProject
-        // are not copied when re-generating the app with a new name
-        //
-        // See https://github.com/tomdale/ember-cli-addon-tests/issues/27
-        app.editPackageJSON(function(pkg) {
-          pkg['devDependencies']['ember-web-app-rename'] = '*';
-        });
       })
       .then(function() {
         return app.runEmberCommand('build')

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "console-ui": "^1.0.2",
     "ember-ajax": "^2.0.1",
     "ember-cli": "2.8.0",
-    "ember-cli-addon-tests": "^0.4.1",
+    "ember-cli-addon-tests": "^0.4.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-blueprint-test-helpers": "0.13.0",
     "ember-cli-dependency-checker": "^1.2.0",


### PR DESCRIPTION
ember-cli-addon-tests@0.4.2 fixes an issue where packages installed by
the addon weren't copied over next tests.

See https://github.com/tomdale/ember-cli-addon-tests/issues/27