### PR TITLE
Fix documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ manifest.lang = "es-UY";
 
 | Target     | Generates |
 | ---        | ---       |
-| `manifest` | `{ "lang": "en-UY" }`
+| `manifest` | `{ "lang": "es-UY" }`
 | `apple`    | does not apply
 | `ms`       | does not apply
 | `android`  | does not apply


### PR DESCRIPTION
the configuration `manifest.lang = "es-UY";` generates `{ "lang": "es-UY" }` not `{ "lang": "en-UY" }`