### PR TITLE
Fix broccoli rebuild

### DIFF
--- a/lib/broccoli/generate-manifest-json.js
+++ b/lib/broccoli/generate-manifest-json.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var Plugin = require('broccoli-plugin');
+const Plugin = require('broccoli-plugin');
+const fs = require('fs');
+const path = require('path');
 
 module.exports = GenerateManifest;
 
@@ -9,7 +11,8 @@ GenerateManifest.prototype.constructor = GenerateManifest;
 function GenerateManifest(manifest, manifestName) {
   // We don't need any input node
   Plugin.call(this, [], {
-    annotation: 'generate manifest.json'
+    annotation: 'generate manifest.json',
+    persistentOutput: true
   });
 
   this.manifest = manifest;
@@ -17,10 +20,13 @@ function GenerateManifest(manifest, manifestName) {
 }
 
 GenerateManifest.prototype.build = function() {
-  var writeFileSync = require('fs').writeFileSync;
-  var join = require('path').join;
+  let outputFilePath = path.join(this.outputPath, this.manifestName);
 
-  writeFileSync(
-    join(this.outputPath, this.manifestName),
+  if (fs.existsSync(outputFilePath)) {
+    return;
+  }
+
+  fs.writeFileSync(
+    outputFilePath,
     JSON.stringify(this.manifest) + '\n');
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": "https://github.com/san650/ember-web-app.git",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "author": "Santiago Ferreira",
   "license": "MIT",


### PR DESCRIPTION
The manifest was rewritten on each incremental build. As a side effect, CSS hot reloading was not working, the browser would always do a full reload!

*Note: I updated `engine` to `>= 4`, so we can use some ES6. Hope that's ok!*