### PR TITLE
Support absolute urls in ios icon meta

### DIFF
--- a/lib/apple-link-tags.js
+++ b/lib/apple-link-tags.js
@@ -30,6 +30,10 @@ function appleLinkTags(manifest, config) {
           sizes = '';
         }
 
+        if (/^https?:\/\//i.test(icon.src)) {
+          rootURL = '';
+        }
+
         links.push(`<link rel="apple-touch-icon${precomposed}" href="${rootURL}${icon.src.replace(/^\//,'')}"${sizes}>`);
       }
     }


### PR DESCRIPTION
Fixes https://github.com/san650/ember-web-app/issues/49

Made a simple check for http and https.