### PR TITLE
Remove misspelt array check

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,6 @@ manifest.apple = {
 $ git clone https://github.com/san650/ember-web-app.git
 $ cd $_
 $ yarn          # (or npm install)
-$ bower install
 ```
 
 Running tests

--- a/lib/generate-manifest-from-configuration.js
+++ b/lib/generate-manifest-from-configuration.js
@@ -24,11 +24,6 @@ function generateManifestFromConfiguration(configuration) {
 function copyIcons(iconsDefinition) {
   var icons, copy;
 
-  if ('lenght' in iconsDefinition) {
-    // not an array value?
-    return iconsDefinition;
-  }
-
   icons = [];
 
   for(var icon of iconsDefinition) {


### PR DESCRIPTION
I noticed `'length'` was misspelt in `generate-manifest-from-configuration.js`:

```js
  if ('lenght' in iconsDefinition) {
    // not an array value?
    return iconsDefinition;
  }
```

 but on closer inspection of the conditional, if `'length'` were spelt properly then this conditional would trigger whenever `iconsDefinition` is an array, which I assume is not desired behaviour (tests also fail if the spelling is corrected).

Since there doesn't seem to me to be much point in explicitly allowing non-array values for `icons` in the manifest (I think it [has to](https://developer.mozilla.org/en-US/docs/Web/Manifest#icons) be an array), I think this check should be removed to prevent future confusion.

Bonus: remove `bower install` line from README as there is no `bower.json`.