### PR TITLE
Add 'type' attribute for icons

### DIFF
--- a/lib/favicon-link-tags.js
+++ b/lib/favicon-link-tags.js
@@ -2,26 +2,29 @@
 
 module.exports = faviconLinkTags;
 
-var hasTarget = require('./has-target');
-var resolveURL = require('./resolve-url');
+const hasTarget = require('./has-target');
+const resolveURL = require('./resolve-url');
 
 function faviconLinkTags(manifest, config) {
-  var links = [];
-  var sizes;
-  var rootURL = config.rootURL || '/';
+  const links = [];
+  const rootURL = config.rootURL || '/';
 
   if (manifest.icons && manifest.icons.length) {
-    for (var icon of manifest.icons) {
+    for (let icon of manifest.icons) {
       if (hasTarget(icon, 'favicon')) {
+        let sizes = '';
         if (icon.sizes) {
           sizes = ` sizes="${icon.sizes}"`
-        } else {
-          sizes = '';
+        }
+
+        let type = '';
+        if (icon.type) {
+          type = ` type="${icon.type}"`
         }
 
         const url = resolveURL(rootURL, icon.src);
 
-        links.push(`<link rel="icon" href="${url}"${sizes}>`);
+        links.push(`<link rel="icon" href="${url}"${sizes}${type}>`);
       }
     }
   }

--- a/node-tests/unit/favicon-link-tags-test.js
+++ b/node-tests/unit/favicon-link-tags-test.js
@@ -65,6 +65,68 @@ describe('Unit: faviconLinkTags()', function() {
     assert.deepEqual(faviconLinkTags(manifest, config), expected);
   });
 
+  it('renders sizes attribute when it is defined', function() {
+    var config = {
+      rootURL: '/'
+    };
+    var manifest = {
+      icons: [
+        {
+          src: '/foo/bar.png',
+          sizes: '16x16',
+          targets: ['favicon']
+        }
+      ]
+    };
+
+    var expected = [
+      '<link rel="icon" href="/foo/bar.png" sizes="16x16">',
+    ];
+
+    assert.deepEqual(faviconLinkTags(manifest, config), expected);
+  });
+
+  it('does not render type attribute when is not defined', function() {
+    var config = {
+      rootURL: '/'
+    };
+    var manifest = {
+      icons: [
+        {
+          src: '/foo/bar.png',
+          targets: ['favicon']
+        }
+      ]
+    };
+
+    var expected = [
+      '<link rel="icon" href="/foo/bar.png">',
+    ];
+
+    assert.deepEqual(faviconLinkTags(manifest, config), expected);
+  });
+
+  it('renders type attribute when it is defined', function() {
+    var config = {
+      rootURL: '/'
+    };
+    var manifest = {
+      icons: [
+        {
+          src: '/foo/bar.png',
+          type: 'image/png',
+          targets: ['favicon']
+        }
+      ]
+    };
+
+    var expected = [
+      '<link rel="icon" href="/foo/bar.png" type="image/png">',
+    ];
+
+    assert.deepEqual(faviconLinkTags(manifest, config), expected);
+  });
+
   it('uses \'/\' as rootURL if it is undefined', function() {
     var config = {}
 


### PR DESCRIPTION
This allows to specify types different than `png` (see https://en.wikipedia.org/wiki/Favicon#HTML5_recommendation_for_icons_in_multiple_sizes).