### PR TITLE
Allow override of manifest.display for Apple by setting manifest.apple.webAppCapable

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,33 @@ manifest.apple = false;
 | `ms`       | does not apply
 | `android`  | does not apply
 
+#### `apple.webAppCapable`
+
+> Overrides `manifest.display` for the generation of the `apple-mobile-web-app-capable` meta tag.
+
+Possible values:
+  * `true` Turn on.
+  * `false` Turn off.
+
+Example
+
+```js
+manifest = {
+  display: 'standalone',
+  apple: {
+    webAppCapable: false
+  }
+};
+```
+
+| Target     | Generates |
+| ---        | ---       |
+| `manifest` | does not apply
+| `apple`    | `<meta name="apple-mobile-web-app-capable" content="yes">`
+| `ms`       | does not apply
+| `android`  | does not apply
+
+
 #### `apple.statusBarStyle`
 
 > Sets the style of the status bar for a web application in iOS

--- a/lib/apple-meta-tags.js
+++ b/lib/apple-meta-tags.js
@@ -9,7 +9,10 @@ function appleMetaTags(manifest, config) {
 
   var tags = [];
 
-  if (['fullscreen', 'standalone'].indexOf(manifest.display) > -1) {
+  let webAppCapable = manifest.apple && manifest.apple.webAppCapable;
+  let standalone = ['fullscreen', 'standalone'].indexOf(manifest.display) > -1;
+
+  if ((standalone && webAppCapable !== false) || webAppCapable === true) {
     tags.push('<meta name="apple-mobile-web-app-capable" content="yes">');
   }
 

--- a/node-tests/unit/apple-meta-tags-test.js
+++ b/node-tests/unit/apple-meta-tags-test.js
@@ -57,6 +57,62 @@ describe('Unit: appleMetaTags()', function() {
     assert.ok(actual.indexOf(notExpected) === -1);
   });
 
+  it('does not return `web-app-capable` meta tag when display mode is fullscreen, but apple.webAppCapable is false', function() {
+    var manifest = {
+      display: 'fullscreen',
+      apple: {
+        webAppCapable: false
+      }
+    };
+    var notExpected = '<meta name="apple-mobile-web-app-capable" content="yes">';
+
+    var actual = appleMetaTags(manifest);
+
+    assert.ok(actual.indexOf(notExpected) === -1);
+  });
+
+  it('does not return `web-app-capable` meta tag when display mode is standalone, but apple.webAppCapable is false', function() {
+    var manifest = {
+      display: 'standalone',
+      apple: {
+        webAppCapable: false
+      }
+    };
+    var notExpected = '<meta name="apple-mobile-web-app-capable" content="yes">';
+
+    var actual = appleMetaTags(manifest);
+
+    assert.ok(actual.indexOf(notExpected) === -1);
+  });
+
+  it('returns `web-app-capable` meta tag when display mode is browser, but apple.webAppCapable is true', function() {
+    var manifest = {
+      display: 'browser',
+      apple: {
+        webAppCapable: true
+      }
+    };
+    var expected = '<meta name="apple-mobile-web-app-capable" content="yes">';
+
+    var actual = appleMetaTags(manifest);
+
+    assert.ok(actual.indexOf(expected) > -1);
+  });
+
+  it('returns `web-app-capable` meta tag when display mode is browser, but apple.webAppCapable is true', function() {
+    var manifest = {
+      display: 'minimal-ui',
+      apple: {
+        webAppCapable: true
+      }
+    };
+    var expected = '<meta name="apple-mobile-web-app-capable" content="yes">';
+
+    var actual = appleMetaTags(manifest);
+
+    assert.ok(actual.indexOf(expected) > -1);
+  });
+
   it('returns `web-app-title` meta tag', function() {
     var manifest = { name: 'foo bar' };
     var expected = '<meta name="apple-mobile-web-app-title" content="foo bar">';


### PR DESCRIPTION
iOS' standalone mode does not work properly for an app that we built,
but is does work well on Android, so it would be cool to have a way of
overriding the generation of the Apple meta tag.