### PR TITLE
Add an icon option to support Safari's Pinned Tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Image object members:
   * `type` A hint as to the media type of the image.
   * `targets` **Non standard** Targets for the images. ['manifest', 'apple'] by default.
   * `element` **Non standard** Only when the target is `ms`. Must be one of `square70x70logo`, `square150x150logo`, `wide310x150logo` or `square310x310logo`.
+  * `safariPinnedTabColor` **Non standard** Only when the target is `safari-pinned-tab`. Can specify a single color with a hexadecimal value (#990000), an RGB value (rgb(153, 0, 0)), or a recognized color-keyword, such as: red, lime, or navy..
 
 Example
 
@@ -412,7 +413,12 @@ icons: [
   {
     src: '/bar/ms.png',
     element: 'square70x70logo', // non-standard property
-    targets: ['ms'] // non-standard-prroperty
+    targets: ['ms'] // non-standard-property
+  },
+  {
+    src: '/foo/monochrome.svg',
+    safariPinnedTabColor: '#cc6600', // non-standard property
+    targets: ['safari-pinned-tab'] // non-standard-property
   }
 ];
 ```
@@ -424,6 +430,7 @@ icons: [
 | `android`  | does not apply
 | `favicon`  | `<link rel="icon" href="/bar/fav.png" sizes="32x32">`
 | `ms`       | icon in `browserconfig.xml`
+| `safari-pinned-tab`    | `<link rel="mask-icon" href="/foo/monochrome.svg" color="#cc6600">`
 
 #### `lang`
 

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ module.exports = {
 
       tags = tags.concat(require('./lib/android-link-tags')(config, MANIFEST_NAME));
       tags = tags.concat(require('./lib/apple-link-tags')(this.manifestConfiguration, config));
+      tags = tags.concat(require('./lib/safari-pinned-tab-tags')(this.manifestConfiguration, config));
       tags = tags.concat(require('./lib/favicon-link-tags')(this.manifestConfiguration, config));
 
       tags = tags.concat(require('./lib/android-meta-tags')(this.manifestConfiguration, config));

--- a/lib/safari-pinned-tab-tags.js
+++ b/lib/safari-pinned-tab-tags.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = safariPinnedTabTags;
+
+const hasTarget = require('./has-target');
+const resolveURL = require('./resolve-url');
+
+function safariPinnedTabTags(manifest, config) {
+  const links = [];
+  const rootURL = config.rootURL || '/';
+
+  if (manifest.icons && manifest.icons.length) {
+    for (let icon of manifest.icons) {
+      if (hasTarget(icon, 'safari-pinned-tab')) {
+
+        let color = '';
+        if (icon.safariPinnedTabColor) {
+          color = ` color="${icon.safariPinnedTabColor}"`
+        }
+
+        const url = resolveURL(rootURL, icon.src);
+
+        links.push(`<link rel="mask-icon" href="${url}"${color}>`);
+      }
+    }
+  }
+
+  return links;
+}

--- a/node-tests/acceptance/browserconfig-test.js
+++ b/node-tests/acceptance/browserconfig-test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 let assert = require('assert');
-let RSVP = require('rsvp');
 let fs = require('fs');
 let AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
 

--- a/node-tests/acceptance/manifest-test.js
+++ b/node-tests/acceptance/manifest-test.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var RSVP = require('rsvp');
 var fs = require('fs');
 var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
 

--- a/node-tests/unit/index-test.js
+++ b/node-tests/unit/index-test.js
@@ -2,8 +2,6 @@
 
 var assert = require('assert');
 var pristineIndex = require('../../index');
-var MockUI = require('console-ui/mock');
-var stripAnsi = require('strip-ansi');
 
 function createIndex() {
   return Object.assign(
@@ -68,6 +66,23 @@ describe('Unit: index', function() {
       index._disabled = function() { return true; };
 
       assert.ok(!index.contentFor('head', { rootURL: '/' }), 'Doesn\'t include meta tags when disabled');
+    });
+
+    it('returns safari pinned tab link tags', function() {
+      var expected = '<link rel="mask-icon" href="/foo/bar.svg" color="red">';
+      var index = createIndex();
+
+      index.manifestConfiguration = {
+        icons: [
+          {
+            src: '/foo/bar.svg',
+            safariPinnedTabColor: 'red',
+            targets: ['safari-pinned-tab'],
+          }
+        ]
+      };
+
+      assert.ok(index.contentFor('head', { rootURL: '/' }).includes(expected));
     });
   });
 });

--- a/node-tests/unit/safari-pinned-tabs-test.js
+++ b/node-tests/unit/safari-pinned-tabs-test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+var assert = require('assert');
+var safariPinnedTabTags = require('../../lib/safari-pinned-tab-tags');
+
+describe('Unit: safariPinnedTabs()', function() {
+  it('excludes icons that are not targeted for pinned tabs', function() {
+    var config = {
+      rootURL: '/qux/'
+    };
+    var manifest = {
+      icons: [
+        {
+          src: '/foo/bar.png',
+          sizes: '180x180',
+          targets: ['manifest']
+        },
+        {
+          src: '/bar/baz.png',
+          sizes: '280x280'
+        }
+      ]
+    };
+
+    var expected = [];
+
+    assert.deepEqual(safariPinnedTabTags(manifest, config), expected);
+  });
+
+  it('returns empty array when icons is not defined', function() {
+    var config = {};
+    var manifest = {};
+    var expected = [];
+
+    assert.deepEqual(safariPinnedTabTags(manifest, config), expected);
+  });
+
+  it('returns empty array when icons is empty', function() {
+    var config = {};
+    var manifest = {
+      icons: []
+    };
+    var expected = [];
+
+    assert.deepEqual(safariPinnedTabTags(manifest, config), expected);
+  });
+
+  it('renders color attribute', function() {
+    var config = {
+      rootURL: '/'
+    };
+    var manifest = {
+      icons: [
+        {
+          src: '/foo/bar.svg',
+          targets: ['safari-pinned-tab'],
+          safariPinnedTabColor: '#abc'
+        }
+      ]
+    };
+
+    var expected = [
+      '<link rel="mask-icon" href="/foo/bar.svg" color="#abc">',
+    ];
+
+    assert.deepEqual(safariPinnedTabTags(manifest, config), expected);
+  });
+
+  it('uses \'/\' as rootURL if it is undefined', function() {
+    var config = {}
+
+    var manifest = {
+      icons: [
+        {
+          src: 'bar.svg',
+          targets: ['safari-pinned-tab']
+        }
+      ]
+    };
+
+    var expected = [
+      '<link rel="mask-icon" href="/bar.svg">',
+    ];
+
+    assert.deepEqual(safariPinnedTabTags(manifest, config), expected);
+  });
+
+  it('respects absolute urls', function() {
+    var config = {
+      rootURL: '/qux/'
+    };
+    var manifest = {
+      icons: [
+        {
+          src: 'http://www.example.com/foo/bar.svg',
+          targets: ['safari-pinned-tab']
+        },
+        {
+          src: 'https://www.example.com/bar/baz.svg',
+          targets: ['safari-pinned-tab']
+        }
+      ]
+    };
+
+    var expected = [
+      '<link rel="mask-icon" href="http://www.example.com/foo/bar.svg">',
+      '<link rel="mask-icon" href="https://www.example.com/bar/baz.svg">'
+    ];
+
+    assert.deepEqual(safariPinnedTabTags(manifest, config), expected);
+  });
+});


### PR DESCRIPTION
Adds a target option for `safari-pinned-tab` and an extra
`safariPinnedTabColor` attribute to support

https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/pinnedTabs/pinnedTabs.html

I went with the most verbose property names, let me know if you want something more compact or if there is anything else I should change.

Fixes #15 