### PR TITLE
Use empty string as fallback when rootURL is not defined

### DIFF
--- a/lib/android-link-tags.js
+++ b/lib/android-link-tags.js
@@ -4,7 +4,9 @@ module.exports = androidLinkTags;
 
 function androidLinkTags(config, manifestName) {
   var resolveURL = require('./resolve-url');
-  var rootURL = config.rootURL || '/';
+  var resolveRootURL = require('./resolve-root-url');
+
+  var rootURL = resolveRootURL(config);
   var url = resolveURL(rootURL, manifestName);
 
   return [

--- a/lib/apple-link-tags.js
+++ b/lib/apple-link-tags.js
@@ -4,6 +4,7 @@ module.exports = appleLinkTags;
 
 var hasTarget = require('./has-target');
 var resolveURL = require('./resolve-url');
+var resolveRootURL = require('./resolve-root-url');
 
 function appleLinkTags(manifest, config) {
   if (manifest.apple === false) {
@@ -12,7 +13,7 @@ function appleLinkTags(manifest, config) {
 
   var links = [];
   var sizes;
-  var rootURL = config.rootURL || '/';
+  var rootURL = resolveRootURL(config);
 
   var precomposed;
 

--- a/lib/favicon-link-tags.js
+++ b/lib/favicon-link-tags.js
@@ -4,10 +4,11 @@ module.exports = faviconLinkTags;
 
 const hasTarget = require('./has-target');
 const resolveURL = require('./resolve-url');
+const resolveRootURL = require('./resolve-root-url');
 
 function faviconLinkTags(manifest, config) {
   const links = [];
-  const rootURL = config.rootURL || '/';
+  const rootURL = resolveRootURL(config);
 
   if (manifest.icons && manifest.icons.length) {
     for (let icon of manifest.icons) {

--- a/lib/ms-meta-tags.js
+++ b/lib/ms-meta-tags.js
@@ -7,7 +7,9 @@ module.exports = msMetaTags;
 function msMetaTags(manifest, config, browserconfigName) {
   if (GenerateBrowserconfig.shouldGenerateBrowserconfig(manifest)) {
     const resolveURL = require('./resolve-url');
-    const rootURL = config.rootURL || '/';
+    const resolveRootURL = require('./resolve-root-url');
+
+    const rootURL = resolveRootURL(config);
     const url = resolveURL(rootURL, browserconfigName);
 
     return [

--- a/lib/resolve-root-url.js
+++ b/lib/resolve-root-url.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = resolveRootURL;
+
+function resolveRootURL(config) {
+  return config.rootURL || '';
+}

--- a/lib/safari-pinned-tab-tags.js
+++ b/lib/safari-pinned-tab-tags.js
@@ -4,10 +4,11 @@ module.exports = safariPinnedTabTags;
 
 const hasTarget = require('./has-target');
 const resolveURL = require('./resolve-url');
+const resolveRootURL = require('./resolve-root-url');
 
 function safariPinnedTabTags(manifest, config) {
   const links = [];
-  const rootURL = config.rootURL || '/';
+  const rootURL = resolveRootURL(config);
 
   if (manifest.icons && manifest.icons.length) {
     for (let icon of manifest.icons) {

--- a/node-tests/unit/android-link-tags-test.js
+++ b/node-tests/unit/android-link-tags-test.js
@@ -8,7 +8,7 @@ describe('Unit: androidLinkTags()', function() {
     var manifest = {};
     var config = {};
     var expected = [
-      '<link rel="manifest" href="/manifest.webmanifest">'
+      '<link rel="manifest" href="manifest.webmanifest">'
     ];
 
     assert.deepEqual(androidLinkTags(config, 'manifest.webmanifest'), expected);

--- a/node-tests/unit/apple-link-tags-test.js
+++ b/node-tests/unit/apple-link-tags-test.js
@@ -91,7 +91,7 @@ describe('Unit: appleLinkTags()', function() {
     assert.deepEqual(appleLinkTags(manifest, config), expected);
   });
 
-  it('uses \'/\' as rootURL if it is undefined', function() {
+  it('uses an empty string as rootURL if it is undefined', function() {
     var config = {}
 
     var manifest = {
@@ -103,7 +103,7 @@ describe('Unit: appleLinkTags()', function() {
     };
 
     var expected = [
-      '<link rel="apple-touch-icon" href="/bar.png">',
+      '<link rel="apple-touch-icon" href="bar.png">',
     ];
 
     assert.deepEqual(appleLinkTags(manifest, config), expected);

--- a/node-tests/unit/favicon-link-tags-test.js
+++ b/node-tests/unit/favicon-link-tags-test.js
@@ -127,7 +127,7 @@ describe('Unit: faviconLinkTags()', function() {
     assert.deepEqual(faviconLinkTags(manifest, config), expected);
   });
 
-  it('uses \'/\' as rootURL if it is undefined', function() {
+  it('uses an empty string as rootURL if it is undefined', function() {
     var config = {}
 
     var manifest = {
@@ -140,7 +140,7 @@ describe('Unit: faviconLinkTags()', function() {
     };
 
     var expected = [
-      '<link rel="icon" href="/bar.png">',
+      '<link rel="icon" href="bar.png">',
     ];
 
     assert.deepEqual(faviconLinkTags(manifest, config), expected);

--- a/node-tests/unit/ms-meta-tags-test.js
+++ b/node-tests/unit/ms-meta-tags-test.js
@@ -13,7 +13,7 @@ describe('Unit: msMetaTags()', function() {
     assert.deepEqual(
       msMetaTags(manifest, config, 'browserconfig.xml'),
       [
-        '<meta name="msapplication-config" content="/browserconfig.xml">'
+        '<meta name="msapplication-config" content="browserconfig.xml">'
       ]
     );
   });

--- a/node-tests/unit/safari-pinned-tabs-test.js
+++ b/node-tests/unit/safari-pinned-tabs-test.js
@@ -66,7 +66,7 @@ describe('Unit: safariPinnedTabs()', function() {
     assert.deepEqual(safariPinnedTabTags(manifest, config), expected);
   });
 
-  it('uses \'/\' as rootURL if it is undefined', function() {
+  it('uses an empty string as rootURL if it is undefined', function() {
     var config = {}
 
     var manifest = {
@@ -79,7 +79,7 @@ describe('Unit: safariPinnedTabs()', function() {
     };
 
     var expected = [
-      '<link rel="mask-icon" href="/bar.svg">',
+      '<link rel="mask-icon" href="bar.svg">',
     ];
 
     assert.deepEqual(safariPinnedTabTags(manifest, config), expected);


### PR DESCRIPTION
This allows to use URLs which are relative to the index.html
This PR is inspired by https://github.com/san650/ember-web-app/pull/68