### PR TITLE
change asset generating example code to be more generalizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,11 +748,17 @@ If your `manifest.js` looks like this and needs a 192px and a 512px icon:
 // config/manifest.js
 export default function() {
   return {
-    icons: [192, 512].map((size) => ({
-      src: `/assets/icons/appicon-${size}.png`,
-      sizes: `${size}x${size}`,
-      type: "image/png"
-    }))
+    icons: [
+      {
+        src: '/assets/icons/appicon-32.png',
+        sizes: `32x32`,
+        targets: ['favicon']
+      },
+      ...[192, 280, 512].map((size) => ({
+        src: `/assets/icons/appicon-${size}.png`,
+        sizes: `${size}x${size}`
+      }))
+    ]
   };
 }
 ```
@@ -770,7 +776,7 @@ module.exports = function(defaults) {
           outputFileName: 'appicon-',
           convertTo: 'png',
           destination: 'assets/icons/',
-          sizes: [192, 512]
+          sizes: [32, 192, 280, 512]
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -749,7 +749,7 @@ If your `manifest.js` looks like this and needs a 192px and a 512px icon:
 export default function() {
   return {
     icons: [192, 512].map((size) => ({
-      src: `/images/icons/android-chrome-${size}.png`,
+      src: `/assets/icons/appicon-${size}.png`,
       sizes: `${size}`,
       type: "image/png"
     }))
@@ -767,9 +767,9 @@ module.exports = function(defaults) {
       images: [
         {
           inputFilename: 'lib/images/brand-icon.svg',
-          outputFileName: 'android-chrome-',
+          outputFileName: 'appicon-',
           convertTo: 'png',
-          destination: 'images/icons/',
+          destination: 'assets/icons/',
           sizes: [192, 512]
         }
       ]

--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ export default function() {
   return {
     icons: [192, 512].map((size) => ({
       src: `/assets/icons/appicon-${size}.png`,
-      sizes: `${size}`,
+      sizes: `${size}x${size}`,
       type: "image/png"
     }))
   };


### PR DESCRIPTION
- asset-cache by default caches things in `assets/`, so putting the images there~
- I want these to work on iOS as well as android - I don't think the file names need to say android chrome?