### PR TITLE
Fix element attribute for MS icon in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ module.exports = function() {
       },
       {
         src: "/images/icons/mstile-150x150.png",
-        element: "150x150",
+        element: "square150x150logo",
         targets: ['ms']
       }
     ],


### PR DESCRIPTION
Currently, we have an error with the example in the build:
``èrror
The 'element' property of the icon for browserconfig.xml must be one of square70x70logo, square150x150logo, wide310x150logo, square310x310logo
```