### PR TITLE
add application name tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,9 @@ module.exports = {
       return;
     }
 
-    if (section === 'head') {
+    let contentForSection = this.addonBuildConfig.contentForSection || 'head';
+
+    if (section === contentForSection) {
       let tags = [];
 
       tags = tags.concat(require('./lib/android-link-tags')(config, MANIFEST_NAME));

--- a/lib/android-meta-tags.js
+++ b/lib/android-meta-tags.js
@@ -3,11 +3,15 @@
 module.exports = androidMetaTags;
 
 function androidMetaTags(manifest) {
-  if (manifest.theme_color) {
-    return [
-      '<meta name="theme-color" content="' + manifest.theme_color + '">'
-    ];
-  } else {
-    return [];
+  let tags = [];
+
+  if (manifest.name) {
+    tags.push('<meta name="application-name" content="' + manifest.name + '">');
   }
+
+  if (manifest.theme_color) {
+    tags.push('<meta name="theme-color" content="' + manifest.theme_color + '">');
+  }
+
+  return tags;
 }


### PR DESCRIPTION
- add `application-name` tag so android will default to name defined in manifest.
- allow option to render into alternate content for section